### PR TITLE
Rewire around a different router package.

### DIFF
--- a/pkg/server/constructor.go
+++ b/pkg/server/constructor.go
@@ -3,15 +3,15 @@ package server
 import (
 	"log"
 
+	"github.com/go-chi/chi"
 	"github.com/jlucktay/rest-api/pkg/storage/inmemory"
 	"github.com/jlucktay/rest-api/pkg/storage/mongo"
-	"github.com/julienschmidt/httprouter"
 )
 
 // New creates a new Server utilising the given StorageType to handle Payment storage, and sets up the HTTP router.
 func New(st StorageType) *Server {
 	s := &Server{
-		Router: httprouter.New(),
+		Router: chi.NewRouter(),
 	}
 	s.setupRoutes()
 

--- a/pkg/server/constructor.routes.go
+++ b/pkg/server/constructor.routes.go
@@ -1,19 +1,17 @@
 package server
 
 func (s *Server) setupRoutes() {
-	s.Router.HandleMethodNotAllowed = true
-
 	// C
-	s.Router.POST("/payments", s.createPayments())
-	s.Router.POST("/payments/:id", s.createPaymentByID())
+	s.Router.Post("/payments", s.createPayments())
+	s.Router.Post("/payments/{id}", s.createPaymentByID())
 
 	// R
-	s.Router.GET("/payments", s.readPayments())
-	s.Router.GET("/payments/:id", s.readPaymentByID())
+	s.Router.Get("/payments", s.readPayments())
+	s.Router.Get("/payments/{id}", s.readPaymentByID())
 
 	// U
-	s.Router.PUT("/payments/:id", s.updatePaymentByID())
+	s.Router.Put("/payments/{id}", s.updatePaymentByID())
 
 	// D
-	s.Router.DELETE("/payments/:id", s.deletePaymentByID())
+	s.Router.Delete("/payments/{id}", s.deletePaymentByID())
 }

--- a/pkg/server/handlers.create.go
+++ b/pkg/server/handlers.create.go
@@ -7,13 +7,13 @@ import (
 	"log"
 	"net/http"
 
+	"github.com/go-chi/chi"
 	"github.com/gofrs/uuid"
 	"github.com/jlucktay/rest-api/pkg/storage"
-	"github.com/julienschmidt/httprouter"
 )
 
-func (s *Server) createPayments() httprouter.Handle {
-	return func(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+func (s *Server) createPayments() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
 		if r.ContentLength == 0 {
 			http.Error(w, "Empty request body.", http.StatusBadRequest) // 400
 			return
@@ -41,9 +41,9 @@ func (s *Server) createPayments() httprouter.Handle {
 	}
 }
 
-func (s *Server) createPaymentByID() httprouter.Handle {
-	return func(w http.ResponseWriter, r *http.Request, p httprouter.Params) {
-		id := uuid.FromStringOrNil(p.ByName("id"))
+func (s *Server) createPaymentByID() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		id := uuid.FromStringOrNil(chi.URLParam(r, "id"))
 
 		if id == uuid.Nil {
 			http.Error(w, "Invalid ID.", http.StatusNotFound) // 404

--- a/pkg/server/handlers.delete.go
+++ b/pkg/server/handlers.delete.go
@@ -3,14 +3,14 @@ package server
 import (
 	"net/http"
 
+	"github.com/go-chi/chi"
 	"github.com/gofrs/uuid"
 	"github.com/jlucktay/rest-api/pkg/storage"
-	"github.com/julienschmidt/httprouter"
 )
 
-func (a *Server) deletePaymentByID() httprouter.Handle {
-	return func(w http.ResponseWriter, r *http.Request, p httprouter.Params) {
-		id := uuid.FromStringOrNil(p.ByName("id"))
+func (a *Server) deletePaymentByID() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		id := uuid.FromStringOrNil(chi.URLParam(r, "id"))
 
 		if id == uuid.Nil {
 			http.Error(w, "Invalid ID.", http.StatusNotFound) // 404

--- a/pkg/server/handlers.read.go
+++ b/pkg/server/handlers.read.go
@@ -8,13 +8,13 @@ import (
 	"sort"
 	"strconv"
 
+	"github.com/go-chi/chi"
 	"github.com/gofrs/uuid"
 	"github.com/jlucktay/rest-api/pkg/storage"
-	"github.com/julienschmidt/httprouter"
 )
 
-func (s *Server) readPayments() httprouter.Handle {
-	return func(w http.ResponseWriter, r *http.Request, p httprouter.Params) {
+func (s *Server) readPayments() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
 		var opts storage.ReadAllOptions
 		if errLimit := applyFromQuery(r, "limit", &opts.Limit); errLimit != nil {
 			http.Error(w, errLimit.Error(), http.StatusBadRequest)
@@ -65,9 +65,9 @@ func (s *Server) readPayments() httprouter.Handle {
 	}
 }
 
-func (s *Server) readPaymentByID() httprouter.Handle {
-	return func(w http.ResponseWriter, r *http.Request, p httprouter.Params) {
-		id := uuid.FromStringOrNil(p.ByName("id"))
+func (s *Server) readPaymentByID() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		id := uuid.FromStringOrNil(chi.URLParam(r, "id"))
 
 		if id == uuid.Nil {
 			http.Error(w, "Invalid ID.", http.StatusNotFound) // 404

--- a/pkg/server/handlers.update.go
+++ b/pkg/server/handlers.update.go
@@ -6,14 +6,14 @@ import (
 	"log"
 	"net/http"
 
+	"github.com/go-chi/chi"
 	"github.com/gofrs/uuid"
 	"github.com/jlucktay/rest-api/pkg/storage"
-	"github.com/julienschmidt/httprouter"
 )
 
-func (s *Server) updatePaymentByID() httprouter.Handle {
-	return func(w http.ResponseWriter, r *http.Request, p httprouter.Params) {
-		id := uuid.FromStringOrNil(p.ByName("id"))
+func (s *Server) updatePaymentByID() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		id := uuid.FromStringOrNil(chi.URLParam(r, "id"))
 
 		if id == uuid.Nil {
 			http.Error(w, "Invalid ID.", http.StatusNotFound) // 404

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1,13 +1,13 @@
 package server
 
 import (
+	"github.com/go-chi/chi"
 	"github.com/jlucktay/rest-api/pkg/storage"
-	"github.com/julienschmidt/httprouter"
 )
 
 // Server is a RESTful HTTP API server offering CRUD functionality to store Payments.
 type Server struct {
-	Router  *httprouter.Router
+	Router  *chi.Mux
 	Storage storage.PaymentStorage
 }
 


### PR DESCRIPTION
The julienschmidt/httprouter package hasn't been updated for about 6
months now, so I've rewired the routing aspect of the API server to use
go-chi/chi instead.
It was a surprisingly straightforward and painless process, to switch
packages! Nice reassurance from having all of my pre-existing test
coverage too.